### PR TITLE
update reference of hive to trino

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Trino is not included in current [Feast](https://github.com/feast-dev/feast) roa
 pip install feast
 ```
 
-#### Install feast-hive
+#### Install feast-trino
 
 - Install stable version
 
@@ -39,14 +39,14 @@ cd feature_repo
 
 #### Edit `feature_store.yaml`
 
-set `offline_store` type to be `feast_hive.TrinoOfflineStore`
+set `offline_store` type to be `feast_trino.TrinoOfflineStore`
 
 ```yaml
 project: ...
 registry: ...
 provider: local
 offline_store:
-    type: feast_hive.TrinoOfflineStore
+    type: feast_trino.TrinoOfflineStore
     host: localhost
     port: 8080
     user: feast


### PR DESCRIPTION
**What this PR does / why we need it**:
Update text that was referencing `hive` instead of `trino` at some places

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
