### PR TITLE
Add linter in GH actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,13 @@
-<!--  Thanks for sending a pull request!  Here are some tips for you:
-
-1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
-2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
-3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
-4. Make sure documentation is updated for your PR!
-5. Make sure you have signed the CLA https://cla.developers.google.com/clas
-
--->
-
-**What this PR does / why we need it**:
-
 **Which issue(s) this PR fixes**:
 <!--
 *Automatically closes linked issue when PR is merged.
 Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
 -->
 Fixes #
+
+
+**What this PR does / why we need it**:
+
 
 **Does this PR introduce a user-facing change?**:
 <!--

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,36 @@
+name: Run linter
+
+on: [pull_request]
+
+jobs:
+  lint-python:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+          architecture: x64
+      - name: Upgrade pip version
+        run: |
+          pip install --upgrade "pip>=21.3.1"
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.pip-cache.outputs.dir }}
+            /opt/hostedtoolcache/Python
+            /Users/runner/hostedtoolcache/Python
+          key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-pip-
+      - name: Install dependencies
+        run: make install-ci-dependencies 
+      - name: Lint
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,11 @@ lint:
 	cd ${ROOT_DIR}; python -m mypy feast_trino/
 	cd ${ROOT_DIR}; python -m isort feast_trino/ --check-only
 	cd ${ROOT_DIR}; python -m flake8 feast_trino/
-	cd ${ROOT_DIR}; python -m black --check feast_trino 
+	cd ${ROOT_DIR}; python -m black --target-version py37 --check feast_trino 
 
 build:
 	rm -rf dist/*
 	python setup.py sdist bdist_wheel
+
+install-ci-dependencies:
+	pip install -e ".[ci]"

--- a/dev.yml
+++ b/dev.yml
@@ -5,5 +5,5 @@ up:
   - python: 3.8.8
   - custom:
       name: Install the dependencies locally
-      met?: pip install -e ".[dev]"
+      met?: make install-ci-dependencies
       meet: "True"

--- a/feast_trino/trino.py
+++ b/feast_trino/trino.py
@@ -80,7 +80,6 @@ class TrinoRetrievalJob(RetrievalJob):
         """
         Triggers the execution of a historical feature retrieval query and exports the results to a Trino table.
         Runs for a maximum amount of time specified by the timeout parameter (defaulting to 30 minutes).
-        
         Args:
             timeout: An optional number of seconds for setting the time limit of the QueryJob.
             retry_cadence: An optional number of seconds for setting how long the job should checked for completion.

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,8 @@ INSTALL_REQUIRE = [
     "trino>=0.305.0,<0.400.0",
 ]
 
-TEST_REQUIRE = ["pytest==6.0.0"]
-
-DEV_REQUIRE = [
+CI_REQUIRE = [
+    "pytest==6.0.0",
     "flake8",
     "black==19.10b0",
     "isort>=5",
@@ -37,8 +36,7 @@ setup(
     packages=["feast_trino"],
     install_requires=INSTALL_REQUIRE,
     extras_require={
-        "dev": DEV_REQUIRE + TEST_REQUIRE,
-        "test": TEST_REQUIRE,
+        "ci": CI_REQUIRE,
     },
     keywords=("feast featurestore trino offlinestore"),
     classifiers=[


### PR DESCRIPTION
Signed-off-by: Matt Delacour <matt.delacour@shopify.com>

**What this PR does / why we need it**:
Add linter into Github actions as a first step for CI

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/Shopify/feast-trino/issues/4

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
