### PR TITLE
Add upload dataframe to trino

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Run unit tests
+
+on: [pull_request]
+
+jobs:
+  unit-tests:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+          architecture: x64
+      - name: Upgrade pip version
+        run: |
+          pip install --upgrade "pip>=21.3.1"
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.pip-cache.outputs.dir }}
+            /opt/hostedtoolcache/Python
+            /Users/runner/hostedtoolcache/Python
+          key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-pip-
+      - name: Install dependencies
+        run: make install-ci-dependencies
+      - name: Install Feast
+        run : pip install feast==0.14.1
+      - name: Start local Trino cluster using Docker
+        run: make start-local-cluster
+      - name: Unit tests
+        run: make test
+      - name: Kill local Trino cluster
+        if: always()
+        run: make kill-local-cluster

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,19 @@ ROOT_DIR 	:= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 format:
 	# Sort
-	cd ${ROOT_DIR}; python -m isort feast_trino/
+	cd ${ROOT_DIR}; python -m isort feast_trino/ tests/
 
 	# Format
-	cd ${ROOT_DIR}; python -m black --target-version py37 feast_trino
+	cd ${ROOT_DIR}; python -m black --target-version py37 feast_trino tests
 
 lint:
-	cd ${ROOT_DIR}; python -m mypy feast_trino/
-	cd ${ROOT_DIR}; python -m isort feast_trino/ --check-only
-	cd ${ROOT_DIR}; python -m flake8 feast_trino/
-	cd ${ROOT_DIR}; python -m black --target-version py37 --check feast_trino 
+	cd ${ROOT_DIR}; python -m mypy feast_trino/ tests/
+	cd ${ROOT_DIR}; python -m isort feast_trino/ tests/ --check-only
+	cd ${ROOT_DIR}; python -m flake8 feast_trino/ tests/
+	cd ${ROOT_DIR}; python -m black --target-version py37 --check feast_trino  tests
+
+test:
+	cd ${ROOT_DIR}; python -m pytest tests/
 
 build:
 	rm -rf dist/*
@@ -22,3 +25,10 @@ build:
 
 install-ci-dependencies:
 	pip install -e ".[ci]"
+
+start-local-cluster:
+	docker run --detach --rm -p 8080:8080 --name trino -v ${ROOT_DIR}/config/catalog/:/etc/catalog/:ro trinodb/trino:364
+	sleep 15
+
+kill-local-cluster:
+	docker stop trino

--- a/config/catalog/memory.properties
+++ b/config/catalog/memory.properties
@@ -1,0 +1,2 @@
+connector.name=memory
+memory.max-data-per-node=128MB

--- a/feast_trino/connectors/memory.py
+++ b/feast_trino/connectors/memory.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+from feast_trino.connectors.utils import (
+    CREATE_SCHEMA_QUERY_TEMPLATE,
+    INSERT_ROWS_QUERY_TEMPLATE,
+    format_pandas_row,
+    get_trino_table_schema_from_dataframe,
+    pandas_dataframe_fix_batches,
+)
+from feast_trino.trino_utils import Trino
+
+
+def upload_pandas_dataframe_to_trino(
+    client: Trino, df: pd.DataFrame, table_ref: str
+) -> None:
+    client.execute_query(
+        CREATE_SCHEMA_QUERY_TEMPLATE.format(
+            table_ref=table_ref, schema=get_trino_table_schema_from_dataframe(df=df)
+        )
+    )
+
+    # Upload batchs of 1M rows at a time
+    for batch_df in pandas_dataframe_fix_batches(df=df, batch_size=1000000):
+        client.execute_query(
+            INSERT_ROWS_QUERY_TEMPLATE.format(
+                table_ref=table_ref,
+                columns=",".join(batch_df.columns),
+                values=format_pandas_row(batch_df),
+            )
+        )

--- a/feast_trino/connectors/utils.py
+++ b/feast_trino/connectors/utils.py
@@ -1,0 +1,52 @@
+from typing import Iterator
+
+import pandas as pd
+import pyarrow
+
+from feast_trino.trino_type_map import pa_to_trino_value_type
+
+CREATE_SCHEMA_QUERY_TEMPLATE = """
+    CREATE TABLE IF NOT EXISTS {table_ref} (
+    {schema}
+)
+"""
+
+INSERT_ROWS_QUERY_TEMPLATE = """
+    INSERT INTO {table_ref} ({columns})
+    VALUES {values}
+"""
+
+
+def get_trino_table_schema_from_dataframe(df: pd.DataFrame) -> str:
+    pyarrow_schema = pyarrow.Table.from_pandas(df).schema
+    trino_schema = []
+    for field in pyarrow_schema:
+        try:
+            trino_type = pa_to_trino_value_type(str(field.type))
+        except KeyError:
+            raise ValueError(
+                f"Not supported type '{field.type}' in entity_df for '{field.name}'."
+            )
+        trino_schema.append((field.name, trino_type))
+
+    return ",".join([f"{col_name} {col_type}" for col_name, col_type in trino_schema])
+
+
+def pandas_dataframe_fix_batches(
+    df: pd.DataFrame, batch_size: int
+) -> Iterator[pd.DataFrame]:
+    for pos in range(0, len(df), batch_size):
+        yield df[pos : pos + batch_size]
+
+
+def format_pandas_row(df: pd.DataFrame) -> str:
+    def _format_value(value: str) -> str:
+        if isinstance(value, str):
+            return f"'{value}'"
+        else:
+            return f"{value}"
+
+    results = []
+    for row in df.values:
+        results.append(f"({','.join([_format_value(v) for v in row])})")
+    return ",".join(results)

--- a/feast_trino/trino.py
+++ b/feast_trino/trino.py
@@ -244,7 +244,14 @@ def _upload_entity_df_and_get_entity_schema(
 
         return entity_schema
     elif isinstance(entity_df, pd.DataFrame):
-        raise InvalidEntityType(type(entity_df))
+        # Placeholder till it's part of the configuration of Trino
+        from feast_trino.connectors.memory import upload_pandas_dataframe_to_trino
+
+        upload_pandas_dataframe_to_trino(
+            client=client, df=entity_df, table_ref=table_name
+        )
+        entity_schema = dict(zip(entity_df.columns, entity_df.dtypes))
+        return entity_schema
     else:
         raise InvalidEntityType(type(entity_df))
 

--- a/feast_trino/trino_utils.py
+++ b/feast_trino/trino_utils.py
@@ -10,9 +10,9 @@ from typing import Any, Dict, List, Optional
 import trino
 from trino.dbapi import Cursor
 
-trino.constants.HEADER_USER = "X-Presto-User"
-trino.constants.HEADER_SCHEMA = "X-Presto-Schema"
-trino.constants.HEADER_CATALOG = "X-Presto-Catalog"
+trino.constants.HEADER_USER = "X-Trino-User"
+trino.constants.HEADER_SCHEMA = "X-Trino-Schema"
+trino.constants.HEADER_CATALOG = "X-Trino-Catalog"
 
 
 class QueryStatus(Enum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from feast_trino.trino_utils import Trino
+
+HOST = "localhost"
+PORT = "8080"
+TEST_SCHEMA = "memory"
+
+
+@pytest.fixture
+def trino_schema():
+    return TEST_SCHEMA
+
+
+@pytest.fixture
+def client():
+    return Trino(user="user", catalog=TEST_SCHEMA, host=HOST, port=PORT)

--- a/tests/connectors/test_memory.py
+++ b/tests/connectors/test_memory.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+from feast_trino.connectors.memory import upload_pandas_dataframe_to_trino
+
+
+def test_base_case(client, trino_schema):
+    table_ref = f"{trino_schema}.ci.my_df"
+    client.execute_query(f"CREATE SCHEMA IF NOT EXISTS {trino_schema}.ci")
+    client.execute_query(f"DROP TABLE IF EXISTS {table_ref}")
+
+    input_df = pd.DataFrame(
+        data={"id": [1, 2, 3], "value": [4, 5, 6], "str": ["a", "b", "c"]}
+    )
+
+    upload_pandas_dataframe_to_trino(client=client, df=input_df, table_ref=table_ref)
+
+    actual_results = client.execute_query(f"SELECT * FROM {table_ref}")
+    actual_df = pd.DataFrame(
+        data=actual_results.data, columns=actual_results.columns_names
+    )
+    pd.testing.assert_frame_equal(input_df, actual_df)


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/Shopify/feast-trino/issues/3


**What this PR does / why we need it**:
This PR adds the ability to upload a pandas dataframe to a Trino cluster. It adds the `memory` connector that it used for the unit tests

This PR also adds a new GH action where it creates a local Trino cluster and perform the necessary unit tests


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add the ability to uploads a pandas dataframe into a Trino cluster
```
