### PR TITLE
Add min reviews with probot shopify

### DIFF
--- a/.github/minimum-reviews.yml
+++ b/.github/minimum-reviews.yml
@@ -1,0 +1,15 @@
+# Number of reviews required to mark the pull request as valid
+reviewsUntilReady: 1
+
+# Number of changes in the pull request to start enforcing the reviewsUntilReady rule
+changesThreshold: 100
+
+# Message to display when the commit status passes
+readyMessage: 'No pending reviews'
+
+# Message to display when the commit status fails
+notReadyMessage: 'Pending review approvals'
+
+# Status to set the commit to when waiting for reviews
+# 'failure, error, and pending' are the suggested options
+notReadyState: 'pending'

--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,2 +1,3 @@
 enabled:
   - cla
+  - minimum-reviews

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Each line is a file pattern followed by one or more owners.
 # https://help.github.com/en/articles/about-code-owners
 
-*           @feast-dev/maintainers @Shopify/ml-platform-team
+*           @woop @achals @tsotnet @felixwang9817 @adchia @Shopify/ml-platform-team


### PR DESCRIPTION
Signed-off-by: Matt Delacour <matt.delacour@shopify.com>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/Shopify/feast-trino/issues/7


**What this PR does / why we need it**:
Today I use Shopify settings which make "min_reviews" only accept Shopify reviewers. Therefore we should use probot so that any reviewer part of the CODEOWNER will be good enough

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
