### PR TITLE
M1 compatibility

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -2,8 +2,15 @@ name: feast-trino
 type: python
 
 up:
-  - python: 3.8.8
+  - python: 3.9.1
   - custom:
       name: Install the dependencies locally
       met?: make install-ci-dependencies
       meet: "True"
+  - custom:
+     name: Reinstall protobuf with M1 compatibility
+     met?: |
+      export CFLAGS="-I$(brew --prefix protobuf)/include"
+      export LDFLAGS="-L$(brew --prefix protobuf)/lib"
+      pip install protobuf==3.17 --force-reinstall --no-deps --install-option="--cpp_implementation"
+     meet: "true"


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**What this PR does / why we need it**:
Make our local development work on M1 Macbooks
✅  `dev up`
✅  `make start-local-cluster`
✅  `make test`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
