### PR TITLE
Add matrix of python and OS versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,12 @@ on: [pull_request]
 
 jobs:
   unit-tests:
+    strategy:
+      matrix:
+        python-version: [ 3.7, 3.8, 3.9 ]
+    env:
+      PYTHON: ${{ matrix.python-version }}
+    
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
@@ -11,7 +17,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Upgrade pip version
         run: |
@@ -32,8 +38,6 @@ jobs:
             ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-pip-
       - name: Install dependencies
         run: make install-ci-dependencies
-      - name: Install Feast
-        run : pip install feast==0.14.1
       - name: Start local Trino cluster using Docker
         run: make start-local-cluster
       - name: Unit tests

--- a/.github/workflows/universal_tests.yml
+++ b/.github/workflows/universal_tests.yml
@@ -4,6 +4,10 @@ on: [pull_request]
 
 jobs:
   universal-tests:
+    strategy:
+      matrix:
+        feast-version: [ v0.15.1, v0.16.1 ]
+
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: make install-ci-dependencies 
       - name: Install feast
-        run: make install-feast-submodule
+        run: make install-feast-submodule FEAST_VERSION=${{ matrix.feast-version }}
       - name: Start local Trino cluster using Docker
         run: make start-local-cluster
       - name: Feast universal tests

--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Trino is not included in current [Feast](https://github.com/feast-dev/feast) roa
 - [TODO, v0.1.0-beta] Publish a beta release in Pypi
 
 ## Version compatibilities
-Here is how the current feast-trino plugin has been tested
+The feast-trino plugin is tested on the following versions of python [3.7, 3.8, 3.9]
 
-| Feast-trino | Python | Feast  | Trino |
-|-------------|--------|--------|-------|
-| Beta        | 3.7    | 0.15.1 | 364   |
+Here is also how the current feast-trino plugin has been tested against different versions of Feast and Trino
+
+| Feast-trino | Feast  | Trino |
+|-------------|--------|-------|
+| Beta        | 0.15.* | 364   |
+| Beta        | 0.16.* | 364   |
 
 ## Quickstart
 


### PR DESCRIPTION
Signed-off-by: Matt Delacour <matt.delacour@shopify.com>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/Shopify/feast-trino/issues/21


**What this PR does / why we need it**:
Add a matrix of python and OS versions for the unit tests workflow.
The linter workflow does not need to run on a matrix nor the universal-test-suite that is needed to check the logic of the code, not the code itself.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
