### PR TITLE
Remove keyword `encording` to parse the long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 NAME = "feast-trino"
 VERSION = "1.0.0"
 DESCRIPTION = "Trino support for Feast offline store"
-with open("README.md", "r", encoding="utf-8") as f:
+with open("README.md", "r") as f:
     LONG_DESCRIPTION = f.read()
 
 INSTALL_REQUIRE = [


### PR DESCRIPTION
Signed-off-by: Matt Delacour <matt.delacour@shopify.com>

**What this PR does / why we need it**:
I don't know which version of python this Shipit is using but the keyword `encording` is not supported ..
![image](https://user-images.githubusercontent.com/18557047/146418615-cf79d621-03ea-4a0b-9e97-9d0e424d2ba8.png)

✅  `make build` works locally

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
