### PR TITLE
Specify explicitely the repository url

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -2,4 +2,4 @@ deploy:
   override:
     - assert-egg-version-tag setup.py
     - python setup.py sdist
-    - twine upload -r pypi -u shopify -p $PYPI_PASSWORD_SHOPIFY dist/*
+    - twine upload --repository-url https://pypi.org -u shopify -p $PYPI_PASSWORD_SHOPIFY dist/*


### PR DESCRIPTION
Signed-off-by: Matt Delacour <matt.delacour@shopify.com>

**What this PR does / why we need it**:
This might be due to the specific version of Twine we use in this shipit but I need to override the repository-url ...
```
$ twine upload -r pypi -u shopify -p $PYPI_PASSWORD_SHOPIFY dist/*
pid: 28083
UploadToDeprecatedPyPIDetected: You're trying to upload to the legacy PyPI site 'https://pypi.python.org/pypi'. Uploading to those sites is deprecated. 
 The new sites are pypi.org and test.pypi.org. Try using https://upload.pypi.org/legacy/ (or https://test.pypi.org/legacy/) to upload your packages instead. These are the default URLs for Twine now. 
 More at https://packaging.python.org/guides/migrating-to-pypi-org/ .
twine upload -r pypi -u shopify -p $PYPI_PASSWORD_SHOPIFY dist/* terminated with exit status 1
```
![image](https://user-images.githubusercontent.com/18557047/146425927-ad276cf3-43d6-4007-aca2-505a18a70b45.png)


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
