### PR TITLE
Update install instruction in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Here is also how the current feast-trino plugin has been tested against differen
 
 #### Install feast-trino
 
+**WARNING**  
+There is currently an issue with pypi with the namespace `feast-trino` (see [PEP 541](https://github.com/pypa/pypi-support/issues/1549)). Until this is solved, you can install feast-trino by doing `pip install git+https://github.com/shopify/feast-trino.git@{SPECIFIC_VERSION}`. For example for `v1.0.0` you can run `pip install git+https://github.com/shopify/feast-trino.git@v1.0.0`
+
 - Install stable version
 
 ```shell
@@ -25,7 +28,7 @@ pip install feast-trino
 - Install develop version (not stable):
 
 ```shell
-pip install git+https://github.com/shopify/feast-trino.git 
+pip install git+https://github.com/shopify/feast-trino.git@main
 ```
 
 #### Create a feature repository


### PR DESCRIPTION
Signed-off-by: Matt Delacour <matt.delacour@shopify.com>


**What this PR does / why we need it**:
With [Feast 0.17.0](https://github.com/feast-dev/feast/releases/tag/v0.17.0), it has been announced that Trino is officially supported by this plugin ([see this PR](https://github.com/feast-dev/feast/pull/2175/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R156)).

Until our [issue with pypi is fixed](https://github.com/pypa/pypi-support/issues/1549), we should make it clear how to install `feast-trino` easily.

This new README https://github.com/Shopify/feast-trino/blob/update_readme_install_instruction/README.md

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
