### PR TITLE
Manual release strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 
 .PHONY: build
 
-ROOT_DIR 	:= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-FEAST_VERSION ?= v0.16.1
-TRINO_VERSION ?= 364
-VERSION 	:=$(shell cat VERSION)
+ROOT_DIR               := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+FEAST_VERSION          ?= v0.16.1
+TRINO_VERSION          ?= 364
+PYPI_PASSWORD_SHOPIFY  ?= WRONG_PASSWORD
+VERSION                := $(shell cat VERSION)
+VERSION_TAG            := v${VERSION}
+MOST_RECENT_TAG        := $(shell git describe --tags --abbrev=0)
+DEFAULT_BRANCH         := main
+GIT_BRANCH_NAME        := $(shell git rev-parse --abbrev-ref HEAD)
 
 format:
 	# Sort
@@ -33,11 +38,39 @@ test-python-universal-ci:
 	mv ${ROOT_DIR}/tests_old ${ROOT_DIR}/tests
 
 build:
-	rm -rf dist/*
-	python setup.py sdist bdist_wheel
+	cd ${ROOT_DIR}; rm -rf dist/*
+	cd ${ROOT_DIR}; python setup.py sdist bdist_wheel
 
 release:
-	git tag -m "Release v${VERSION}" v${VERSION}
+	cd ${ROOT_DIR}; git tag -m "Release ${VERSION_TAG}" ${VERSION_TAG}
+	cd ${ROOT_DIR}; git push --tags origin
+
+unset-release:
+	cd ${ROOT_DIR}; git tag -d ${VERSION_TAG} || true
+	cd ${ROOT_DIR}; git push --delete origin ${VERSION_TAG} || true
+
+publish:
+ifndef PYPI_PASSWORD_SHOPIFY
+	@echo "PYPI_PASSWORD_SHOPIFY environment variable missing"
+	exit 1
+endif
+ifeq (${PYPI_PASSWORD_SHOPIFY}, WRONG_PASSWORD)
+	@echo "Ask your lead to get access to PYPI_PASSWORD_SHOPIFY"
+	exit 1
+endif
+ifneq (${GIT_BRANCH_NAME}, ${DEFAULT_BRANCH})
+	@echo "You can only publish a new package if you are on the ${DEFAULT_BRANCH} branch"
+	exit 1
+endif
+ifneq (${VERSION_TAG}, ${MOST_RECENT_TAG})
+	@echo "The version present in VERSION is different than the most recent version tag"
+	exit 1
+endif
+
+	cd ${ROOT_DIR}; git checkout tags/${VERSION_TAG}
+	make build
+	cd ${ROOT_DIR}; twine upload -u shopify -p ${PYPI_PASSWORD_SHOPIFY} dist/* || true
+	cd ${ROOT_DIR}; git checkout main
 
 install-feast-submodule:
 	cd ${ROOT_DIR}; git submodule add --force https://github.com/feast-dev/feast.git feast

--- a/RELEASING
+++ b/RELEASING
@@ -4,20 +4,17 @@ Releasing feast-trino
 
 2. Check the Semantic Versioning page for info on how to version the new release: http://semver.org
 
-3. Update version in setup.py
+3. Update the version in `VERSION`
 
-4. Update CHANGELOG entry for the release.
+4. Once the PR is ready to be merged, cut a release by doing `PYPI_PASSWORD_SHOPIFY=SHOPIFY_PYPI_PWD make publish`
 
-5. Commit the changes
-    git commit -m "Release vX.Y.Z"
+4.1 If you need to make changes to the PR you can always unset the release by doing `make unset-release` and create a new one once ready to be merged
 
-6. Tag the release with the version
-    git tag -m "Release X.Y.Z" vX.Y.Z
+5. Merge the PR
 
-7. Push the changes to github
-    git push --tags origin main
+6. Go back to the `main` branch and pull the latest changes `git pull origin main`
 
-8. Shipit!
+7. Publish a new release on pypi by doing `make release`
 
-9. Create a new release in github to highlight the main changes
+8. Create a new release in github to highlight the main changes
     https://github.com/Shopify/feast-trino/releases


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


**What this PR does / why we need it**:
Because our Shipit is kinda broken to cut releases in pypi, here is the safe procedure to do it manually. This can only be done by Shopify's employees

Tophat
✅ 
```bash
 ❯ make publish
Ask your lead to get access to PYPI_PASSWORD_SHOPIFY
exit 1
make: *** [publish] Error 1

 ❯ PYPI_PASSWORD_SHOPIFY=AAA make publish
You can only publish a new package if you are on the main branch
exit 1
make: *** [publish] Error 1
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update the RELEASING process
```
