### PR TITLE
add auth and htt_scheme for Authentication and add connectors module

### DIFF
--- a/feast_trino/__init__.py
+++ b/feast_trino/__init__.py
@@ -1,5 +1,14 @@
 import sys
 
+
+from .connectors.utils import (
+    pyarrow_schema_from_dataframe,
+    trino_table_schema_from_dataframe,
+    pandas_dataframe_fix_batches,
+    format_pandas_row,
+    format_datetime,
+)
+from .connectors.upload import upload_pandas_dataframe_to_trino
 from .trino import TrinoOfflineStore, TrinoOfflineStoreConfig
 from .trino_source import TrinoOptions, TrinoSource
 
@@ -15,4 +24,10 @@ __all__ = [
     "TrinoSource",
     "TrinoOfflineStoreConfig",
     "TrinoOfflineStore",
+    "pyarrow_schema_from_dataframe",
+    "trino_table_schema_from_dataframe",
+    "pandas_dataframe_fix_batches",
+    "format_pandas_row",
+    "format_datetime",
+    "upload_pandas_dataframe_to_trino",
 ]

--- a/feast_trino/__init__.py
+++ b/feast_trino/__init__.py
@@ -1,14 +1,13 @@
 import sys
 
-
+from .connectors.upload import upload_pandas_dataframe_to_trino
 from .connectors.utils import (
+    format_datetime,
+    format_pandas_row,
+    pandas_dataframe_fix_batches,
     pyarrow_schema_from_dataframe,
     trino_table_schema_from_dataframe,
-    pandas_dataframe_fix_batches,
-    format_pandas_row,
-    format_datetime,
 )
-from .connectors.upload import upload_pandas_dataframe_to_trino
 from .trino import TrinoOfflineStore, TrinoOfflineStoreConfig
 from .trino_source import TrinoOptions, TrinoSource
 

--- a/feast_trino/feast_tests.py
+++ b/feast_trino/feast_tests.py
@@ -19,7 +19,12 @@ from tests.integration.feature_repos.universal.data_source_creator import (
 class TrinoSourceCreator(DataSourceCreator):
     def __init__(self, project_name: str):
         self.project_name = project_name
-        self.client = Trino(user="user", catalog="memory", host="localhost", port=8080,)
+        self.client = Trino(
+            user="user",
+            catalog="memory",
+            host="localhost",
+            port=8080,
+        )
         self.tables_created: List[str] = []
 
     def create_data_source(
@@ -72,6 +77,7 @@ class TrinoSourceCreator(DataSourceCreator):
 FULL_REPO_CONFIGS = [
     IntegrationTestRepoConfig(),
     IntegrationTestRepoConfig(
-        provider="local", offline_store_creator=TrinoSourceCreator,
+        provider="local",
+        offline_store_creator=TrinoSourceCreator,
     ),
 ]

--- a/feast_trino/feast_tests.py
+++ b/feast_trino/feast_tests.py
@@ -19,12 +19,7 @@ from tests.integration.feature_repos.universal.data_source_creator import (
 class TrinoSourceCreator(DataSourceCreator):
     def __init__(self, project_name: str):
         self.project_name = project_name
-        self.client = Trino(
-            user="user",
-            catalog="memory",
-            host="localhost",
-            port=8080,
-        )
+        self.client = Trino(user="user", catalog="memory", host="localhost", port=8080,)
         self.tables_created: List[str] = []
 
     def create_data_source(
@@ -77,7 +72,6 @@ class TrinoSourceCreator(DataSourceCreator):
 FULL_REPO_CONFIGS = [
     IntegrationTestRepoConfig(),
     IntegrationTestRepoConfig(
-        provider="local",
-        offline_store_creator=TrinoSourceCreator,
+        provider="local", offline_store_creator=TrinoSourceCreator,
     ),
 ]

--- a/feast_trino/trino.py
+++ b/feast_trino/trino.py
@@ -93,11 +93,7 @@ class TrinoRetrievalJob(RetrievalJob):
         """Returns the SQL query that will be executed in Trino to build the historical feature table"""
         return self._query
 
-    def to_trino(
-        self,
-        timeout: int = 1800,
-        retry_cadence: int = 10,
-    ) -> Optional[str]:
+    def to_trino(self, timeout: int = 1800, retry_cadence: int = 10,) -> Optional[str]:
         """
         Triggers the execution of a historical feature retrieval query and exports the results to a Trino table.
         Runs for a maximum amount of time specified by the timeout parameter (defaulting to 30 minutes).
@@ -215,8 +211,8 @@ class TrinoOfflineStore(OfflineStore):
             connector=config.offline_store.connector,
         )
 
-        entity_df_event_timestamp_col = (
-            offline_utils.infer_event_timestamp_from_entity_df(entity_schema)
+        entity_df_event_timestamp_col = offline_utils.infer_event_timestamp_from_entity_df(
+            entity_schema
         )
 
         expected_join_keys = offline_utils.get_expected_join_keys(
@@ -229,10 +225,7 @@ class TrinoOfflineStore(OfflineStore):
 
         # Build a query context containing all information required to template the Trino SQL query
         query_context = offline_utils.get_feature_view_query_context(
-            feature_refs,
-            feature_views,
-            registry,
-            project,
+            feature_refs, feature_views, registry, project,
         )
 
         # Generate the Trino SQL query from the query context

--- a/feast_trino/trino.py
+++ b/feast_trino/trino.py
@@ -125,7 +125,7 @@ class TrinoOfflineStore(OfflineStore):
         end_date: datetime,
         user: str = "user",
         auth: Authentication = None,
-        http_scheme: str = "http",
+        http_scheme: str = None,
     ) -> TrinoRetrievalJob:
         if not isinstance(data_source, TrinoSource):
             raise ValueError(
@@ -286,7 +286,7 @@ def _upload_entity_df_and_get_entity_schema(
     # TODO: Ensure that the table expires after some time
 
 
-def _get_trino_client(config: RepoConfig, user: str, auth: Authentication, http_scheme: str) -> Trino:
+def _get_trino_client(config: RepoConfig, user: str, auth: Optional[Any], http_scheme: Optional[str]) -> Trino:
     client = Trino(
         user=user,
         catalog=config.offline_store.catalog,

--- a/feast_trino/trino_utils.py
+++ b/feast_trino/trino_utils.py
@@ -36,7 +36,7 @@ class Trino:
         user: Optional[str] = None,
         catalog: Optional[str] = None,
         auth: Optional[Any] = None,
-        http_scheme: str = "http",
+        http_scheme: str = None,
     ):
         self.host = host or os.getenv("TRINO_HOST")
         self.port = port or os.getenv("TRINO_PORT")

--- a/feast_trino/trino_utils.py
+++ b/feast_trino/trino_utils.py
@@ -35,17 +35,26 @@ class Trino:
         port: Optional[int] = None,
         user: Optional[str] = None,
         catalog: Optional[str] = None,
+        auth: Optional[Any] = None,
+        http_scheme: str = "http",
     ):
         self.host = host or os.getenv("TRINO_HOST")
         self.port = port or os.getenv("TRINO_PORT")
         self.user = user or os.getenv("TRINO_USER")
         self.catalog = catalog or os.getenv("TRINO_CATALOG")
+        self.auth = auth or os.getenv("TRINO_AUTH")
+        self.http_scheme = http_scheme or os.getenv("TRINO_HTTP_SCHEME")
         self._cursor = None
 
     def _get_cursor(self) -> Cursor:
         if self._cursor is None:
             self._cursor = trino.dbapi.connect(
-                host=self.host, port=self.port, user=self.user, catalog=self.catalog
+                host=self.host,
+                port=self.port,
+                user=self.user,
+                catalog=self.catalog,
+                auth=self.auth,
+                http_scheme=self.http_scheme
             ).cursor()
 
         return self._cursor

--- a/feast_trino/trino_utils.py
+++ b/feast_trino/trino_utils.py
@@ -54,7 +54,7 @@ class Trino:
                 user=self.user,
                 catalog=self.catalog,
                 auth=self.auth,
-                http_scheme=self.http_scheme
+                http_scheme=self.http_scheme,
             ).cursor()
 
         return self._cursor

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "Bug Tracker": "https://github.com/Shopify/feast-trino/issues",
     },
     license="MIT License",
-    packages=["feast_trino"],
+    packages=["feast_trino", "feast_trino.connectors"],
     install_requires=INSTALL_REQUIRE,
     extras_require={
         "ci": CI_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 NAME = "feast-trino"
 DESCRIPTION = "Trino support for Feast offline store"
@@ -35,7 +35,7 @@ setup(
         "Bug Tracker": "https://github.com/Shopify/feast-trino/issues",
     },
     license="MIT License",
-    packages=["feast_trino", "feast_trino.connectors"],
+    packages=find_packages(exclude=['tests*']),
     install_requires=INSTALL_REQUIRE,
     extras_require={
         "ci": CI_REQUIRE,


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
***Issue 1***
```release-note
need 'auth', 'http_scheme' and 'user' argument for using ldap
``` 
Fixes for Issue 1 #
```python
#feast_trino/trino.py


from feast_trino.trino_source import TrinoSource
from feast_trino.trino_utils import Trino
from trino.auth import Authentication
...
class TrinoOfflineStore(OfflineStore):
    @staticmethod
    def pull_latest_from_table_or_query(
        config: RepoConfig,
        data_source: DataSource,
        join_key_columns: List[str],
        feature_name_columns: List[str],
        event_timestamp_column: str,
        created_timestamp_column: Optional[str],
        start_date: datetime,
        end_date: datetime,
        user: str = "user",
        auth: Authentication = None,
        http_scheme: str = "http",
    ) 
...

        client = _get_trino_client(config=config, user=user, auth=auth, http_scheme=http_scheme)

...

def get_historical_features(
        config: RepoConfig,
        feature_views: List[FeatureView],
        feature_refs: List[str],
        entity_df: Union[pd.DataFrame, str],
        registry: Registry,
        project: str,
        full_feature_names: bool = False,
        user: str = "user",
        auth: Authentication = None,
        http_scheme: str = None,
    ) 
...
        client = _get_trino_client(config=config, user=user, auth=auth, http_scheme=http_scheme)
...

def _get_trino_client(config: RepoConfig, user: str, auth: Authentication, http_scheme: str) -> Trino:
    client = Trino(
        user=user, # add user because access is denied if the default value, "user", is used.
        catalog=config.offline_store.catalog,
        host=config.offline_store.host,
        port=config.offline_store.port,
        auth=auth, # for using ldap
        http_scheme=http_scheme, #default is http but need https 
    )
    return client
```


```python
#feast_trino/trino_utils.py


...
class Trino:
    def __init__(
        self,
        host: Optional[str] = None,
        port: Optional[int] = None,
        user: Optional[str] = None,
        catalog: Optional[str] = None,
        auth: Optional[Any] = None,
        http_scheme: str = "http",
    ):
        self.host = host or os.getenv("TRINO_HOST")
        self.port = port or os.getenv("TRINO_PORT")
        self.user = user or os.getenv("TRINO_USER")
        self.catalog = catalog or os.getenv("TRINO_CATALOG")
        self.auth = auth or os.getenv("TRINO_AUTH")
        self.http_scheme = http_scheme or os.getenv("TRINO_HTTP_SCHEME")
        self._cursor = None

    def _get_cursor(self) -> Cursor:
        if self._cursor is None:
            self._cursor = trino.dbapi.connect(
                host=self.host,
                port=self.port,
                user=self.user,
                catalog=self.catalog,
                auth=self.auth,
                http_scheme=self.http_scheme
            ).cursor()

        return self._cursor
...
```

***Issue 2***
```release-note
no module name feast_trino.connectors
``` 
Fixes for Issue 2 #
```python

#setup.py
...
    license="MIT License",
    packages=["feast_trino"],
    packages=["feast_trino", "feast_trino.connectors"],
    install_requires=INSTALL_REQUIRE,
    extras_require={
        "ci": CI_REQUIRE,
...
```
if feast_trino.connectors module is not stable, I think all codes for the feast_trino.connectors module in trino.py should be removed.
