### PR TITLE
🐛 Fix "with statement" in `CREATE_SCHEMA_QUERY_TEMPLATE`

### DIFF
--- a/feast_trino/connectors/utils.py
+++ b/feast_trino/connectors/utils.py
@@ -10,9 +10,9 @@ from feast_trino.trino_type_map import pa_to_trino_value_type
 
 CREATE_SCHEMA_QUERY_TEMPLATE = """
     CREATE TABLE IF NOT EXISTS {table_ref} (
-    {schema}
+        {schema}
+    )
     {with_statement}
-)
 """
 
 INSERT_ROWS_QUERY_TEMPLATE = """


### PR DESCRIPTION
The `CREATE_SCHEMA_QUERY_TEMPLATE` query template that is used in the `upload_pandas_dataframe_to_trino` helper had a typo/bug.

The current version applies the `WITH` statement of table properties to the last column field only.

```sql
    CREATE TABLE IF NOT EXISTS catalog.table_name (
    column_01 type,column_02 type
    WITH (format = 'PARQUET')
)
```

This was not intended of course. In order to use the `WITH` statement to pass table properties instead, I moved it to **after** the column definitions (after the closing parenthesis `)`)

```sql
    CREATE TABLE IF NOT EXISTS catalog.table_name (
        column_01 type,column_02 type
    )
    WITH (format = 'PARQUET')
```
